### PR TITLE
Make dependencies less strict for required addons

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
   "dependencies": {
     "ember-cli-babel": "^5.1.7",
     "ember-cli-htmlbars": "^1.1.1",
-    "ember-one-way-controls": "1.1.2",
-    "ember-truth-helpers": "1.2.0"
+    "ember-one-way-controls": "^1.1.2",
+    "ember-truth-helpers": "^1.2.0"
   },
   "devDependencies": {
     "ember-ajax": "^2.4.1",


### PR DESCRIPTION
This allows the addon to be used where the other addons are present at more recent versions.