### PR TITLE
Update several dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,17 +18,17 @@
   "author": "leojpod",
   "license": "MIT",
   "dependencies": {
-    "ember-cli-babel": "^5.1.7",
-    "ember-cli-htmlbars": "^1.1.1",
-    "ember-one-way-controls": "^1.1.2",
-    "ember-truth-helpers": "^1.2.0"
+    "ember-cli-babel": "^6.0.0",
+    "ember-cli-htmlbars": "^2.0.2",
+    "ember-one-way-controls": "^2.0.0",
+    "ember-truth-helpers": "^1.3.0"
   },
   "devDependencies": {
     "ember-ajax": "^2.4.1",
     "ember-cli": "2.11.1",
     "ember-cli-app-version": "^2.0.0",
     "ember-cli-dependency-checker": "^1.3.0",
-    "ember-cli-htmlbars-inline-precompile": "^0.3.6",
+    "ember-cli-htmlbars-inline-precompile": "^0.4.3",
     "ember-cli-inject-live-reload": "^1.4.1",
     "ember-cli-jshint": "^2.0.1",
     "ember-cli-qunit": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -18,9 +18,9 @@
   "author": "leojpod",
   "license": "MIT",
   "dependencies": {
-    "ember-cli-babel": "^6.0.0",
-    "ember-cli-htmlbars": "^2.0.2",
-    "ember-one-way-controls": "^2.0.0",
+    "ember-cli-babel": "^6.7.1",
+    "ember-cli-htmlbars": "^2.0.3",
+    "ember-one-way-controls": "^2.0.1",
     "ember-truth-helpers": "^1.3.0"
   },
   "devDependencies": {
@@ -28,7 +28,7 @@
     "ember-cli": "2.11.1",
     "ember-cli-app-version": "^2.0.0",
     "ember-cli-dependency-checker": "^1.3.0",
-    "ember-cli-htmlbars-inline-precompile": "^0.4.3",
+    "ember-cli-htmlbars-inline-precompile": "^1.0.1",
     "ember-cli-inject-live-reload": "^1.4.1",
     "ember-cli-jshint": "^2.0.1",
     "ember-cli-qunit": "^3.0.1",


### PR DESCRIPTION
`ember-cli-babel`: Totally backwards compatible. Transpiled code might be slightly different but should behave idetically.
`ember-cli-htmlbars-inline-precompile`: Required update for babel6
`ember-one-way-controls`: Several improvements and a single breaking change on a feature this project doesn't use.
`ember-cli-htmlbars`: No breaking changes, just dropped support to node 0.12
`ember-truth-helpers`: No breaking changes.